### PR TITLE
Updated tag taxonomy

### DIFF
--- a/content/posts/2011-11-29-vcenter-server-appliance-part-1-configuration-and-deployment.md
+++ b/content/posts/2011-11-29-vcenter-server-appliance-part-1-configuration-and-deployment.md
@@ -2,6 +2,7 @@
 title: vCenter Server Appliance. Part 1 - Configuration and deployment
 date: 2011-11-29
 tags:
+- databases
 - linux
 - vmware
 - vsphere

--- a/content/posts/2011-12-02-vcenter-server-appliance-part-3-managing-the-embedded-db2-database.md
+++ b/content/posts/2011-12-02-vcenter-server-appliance-part-3-managing-the-embedded-db2-database.md
@@ -2,6 +2,7 @@
 title: vCenter Server Appliance. Part 3 - Managing the embedded DB2 database
 date: 2011-12-02
 tags:
+- databases
 - linux
 - vmware
 - vsphere

--- a/content/posts/2012-09-05-vcsa-5-1-deployment-and-upgrade.md
+++ b/content/posts/2012-09-05-vcsa-5-1-deployment-and-upgrade.md
@@ -2,6 +2,7 @@
 title: vCSA 5.1 – Deployment and upgrade
 date: 2012-09-05
 tags:
+- databases
 - vsphere
 showComments: true
 ---

--- a/content/posts/2013-10-31-sql-script-for-vcenter-chargeback-database-creation.md
+++ b/content/posts/2013-10-31-sql-script-for-vcenter-chargeback-database-creation.md
@@ -2,6 +2,7 @@
 title: SQL script for vCenter Chargeback database creation
 date: 2013-10-31
 tags:
+- databases
 - vmware
 showComments: true
 ---

--- a/content/posts/2013-12-11-vcenter-chargeback-manager-2-6-now-supports-vcsa-postgres-database.md
+++ b/content/posts/2013-12-11-vcenter-chargeback-manager-2-6-now-supports-vcsa-postgres-database.md
@@ -2,6 +2,7 @@
 title: vCenter Chargeback Manager 2.6 now supports vCSA Postgres database
 date: 2013-12-11
 tags:
+- databases
 - vmware
 - vsphere
 showComments: true

--- a/content/posts/2014-04-29-deploying-openstack-with-kvm-and-vmware-nsx-part-1-nsx-overview-and-initial-setup.md
+++ b/content/posts/2014-04-29-deploying-openstack-with-kvm-and-vmware-nsx-part-1-nsx-overview-and-initial-setup.md
@@ -2,6 +2,7 @@
 title: 'Deploying OpenStack with KVM and VMware NSX - Part 1: NSX overview and initial setup'
 date: 2014-04-29
 tags:
+- distributed-systems
 - linux
 - networking
 - nsx

--- a/content/posts/2014-05-06-deploying-openstack-with-kvm-and-vmware-nsx-part-2-configure-nsx-transport-and-logical-network-views.md
+++ b/content/posts/2014-05-06-deploying-openstack-with-kvm-and-vmware-nsx-part-2-configure-nsx-transport-and-logical-network-views.md
@@ -2,6 +2,7 @@
 title: 'Deploying OpenStack with KVM and VMware NSX - Part 2: Configure NSX Transport and Logical network views'
 date: 2014-05-06
 tags:
+- distributed-systems
 - networking
 - nsx
 - openstack

--- a/content/posts/2014-05-07-deploying-openstack-with-kvm-and-vmware-nsx-part-3-kvm-hypervisor-and-gluster-storage-setup.md
+++ b/content/posts/2014-05-07-deploying-openstack-with-kvm-and-vmware-nsx-part-3-kvm-hypervisor-and-gluster-storage-setup.md
@@ -2,6 +2,7 @@
 title: 'Deploying OpenStack with KVM and VMware NSX - Part 3:  KVM hypervisor and Gluster storage setup'
 date: 2014-05-07
 tags:
+- distributed-systems
 - linux
 - networking
 - nsx

--- a/content/posts/2014-06-23-deploying-openstack-with-kvm-and-vmware-nsx-part-4-deploy-openstack-rdo-with-neutron-integrated-with-nsx.md
+++ b/content/posts/2014-06-23-deploying-openstack-with-kvm-and-vmware-nsx-part-4-deploy-openstack-rdo-with-neutron-integrated-with-nsx.md
@@ -2,6 +2,7 @@
 title: 'Deploying OpenStack with KVM and VMware NSX - Part 4: Deploy OpenStack RDO with Neutron integrated with NSX'
 date: 2014-06-23
 tags:
+- distributed-systems
 - linux
 - networking
 - nsx

--- a/content/posts/2015-02-02-a-first-look-into-vmware-integrated-openstack-vio.md
+++ b/content/posts/2015-02-02-a-first-look-into-vmware-integrated-openstack-vio.md
@@ -2,6 +2,7 @@
 title: 'A first look into VMware Integrated #OpenStack (VIO)'
 date: 2015-02-02
 tags:
+- distributed-systems
 - networking
 - nsx
 - openstack

--- a/content/posts/2015-10-21-upgrading-vmware-integrated-openstack.md
+++ b/content/posts/2015-10-21-upgrading-vmware-integrated-openstack.md
@@ -3,6 +3,7 @@ title: Upgrading VMware Integrated OpenStack
 date: 2015-10-21
 tags:
 - devops
+- distributed-systems
 - openstack
 - sysadmin
 - vmware

--- a/content/posts/2016-10-04-running-openstack-rally-tests-from-a-docker-container.md
+++ b/content/posts/2016-10-04-running-openstack-rally-tests-from-a-docker-container.md
@@ -3,6 +3,7 @@ title: Running OpenStack Rally tests from a Docker container
 date: 2016-10-04
 tags:
 - containers
+- distributed-systems
 - docker
 - linux
 - openstack

--- a/content/posts/2016-10-18-combining-heat-with-openstack-vagrant-provider.md
+++ b/content/posts/2016-10-18-combining-heat-with-openstack-vagrant-provider.md
@@ -3,6 +3,7 @@ title: Combining Heat with OpenStack Vagrant provider
 date: 2016-10-18
 tags:
 - devops
+- distributed-systems
 - openstack
 - virtualization
 showComments: true

--- a/content/posts/2017-05-23-getting-started-with-azure-container-service.md
+++ b/content/posts/2017-05-23-getting-started-with-azure-container-service.md
@@ -5,6 +5,7 @@ tags:
 - azure
 - cloud-native
 - containers
+- distributed-systems
 - docker
 - kubernetes
 showComments: true

--- a/content/posts/2017-09-05-kubernetes-on-azure-with-azure-container-service.md
+++ b/content/posts/2017-09-05-kubernetes-on-azure-with-azure-container-service.md
@@ -5,6 +5,7 @@ tags:
 - azure
 - cloud-native
 - containers
+- distributed-systems
 - docker
 - kubernetes
 showComments: true

--- a/content/posts/2017-09-21-experimenting-with-openshift-and-azure-container-instances.md
+++ b/content/posts/2017-09-21-experimenting-with-openshift-and-azure-container-instances.md
@@ -5,6 +5,7 @@ tags:
 - azure
 - cloud-native
 - containers
+- distributed-systems
 - docker
 - kubernetes
 showComments: true

--- a/content/posts/2017-11-16-howto-enable-rbac-on-your-existing-acs-deployed-kubernetes-cluster.md
+++ b/content/posts/2017-11-16-howto-enable-rbac-on-your-existing-acs-deployed-kubernetes-cluster.md
@@ -5,6 +5,7 @@ tags:
 - azure
 - cloud-native
 - containers
+- distributed-systems
 - kubernetes
 showComments: true
 ---

--- a/content/posts/2018-03-19-running-your-private-kubernetes-cluster-on-azure-with-acs-engine.md
+++ b/content/posts/2018-03-19-running-your-private-kubernetes-cluster-on-azure-with-acs-engine.md
@@ -6,6 +6,7 @@ tags:
 - azure
 - cloud-native
 - containers
+- distributed-systems
 - docker
 - kubernetes
 showComments: true

--- a/content/posts/2019-02-07-kubernetes-version-upgrade-with-aks-engine.md
+++ b/content/posts/2019-02-07-kubernetes-version-upgrade-with-aks-engine.md
@@ -7,6 +7,7 @@ tags:
 - cloud-native
 - containers
 - devops
+- distributed-systems
 - kubernetes
 showComments: true
 ---

--- a/content/posts/2019-06-13-scaling-operations-with-aks-engine.md
+++ b/content/posts/2019-06-13-scaling-operations-with-aks-engine.md
@@ -7,6 +7,7 @@ tags:
 - cloud-native
 - containers
 - devops
+- distributed-systems
 - kubernetes
 showComments: true
 ---

--- a/content/posts/2025-04-28-level-up-your-homelab-autoamtion-with-azure-devops-server.md
+++ b/content/posts/2025-04-28-level-up-your-homelab-autoamtion-with-azure-devops-server.md
@@ -5,6 +5,7 @@ description: "Run Azure DevOps Server Express in your homelab for free CI/CD pip
 tags:
 - azure
 - azure-devops
+- databases
 - devops
 - homelab
 showComments: true

--- a/content/posts/2025-05-14-managing-secrets-securely-in-azure-devOps-server-with-variable-groups.md
+++ b/content/posts/2025-05-14-managing-secrets-securely-in-azure-devOps-server-with-variable-groups.md
@@ -5,6 +5,7 @@ description: "Keep your credentials safe with encrypted Variable Groups in your 
 tags:
 - azure
 - azure-devops
+- databases
 - devops
 showComments: true
 ---

--- a/content/posts/2025-05-26-azure-devops-self-hosted-agents-deep-dive.md
+++ b/content/posts/2025-05-26-azure-devops-self-hosted-agents-deep-dive.md
@@ -6,6 +6,7 @@ tags:
 - azure
 - azure-devops
 - devops
+- distributed-systems
 - homelab
 showComments: true
 ---

--- a/content/posts/2025-09-10-exposing-aks-workloads-on-azure-2025-edition.md
+++ b/content/posts/2025-09-10-exposing-aks-workloads-on-azure-2025-edition.md
@@ -6,6 +6,7 @@ tags:
 - aks
 - azure
 - cloud-native
+- distributed-systems
 - kubernetes
 - networking
 showComments: true

--- a/content/posts/2025-09-19-a-deep-dive-into-the-kubernetes-gateway-api.md
+++ b/content/posts/2025-09-19-a-deep-dive-into-the-kubernetes-gateway-api.md
@@ -5,6 +5,7 @@ description: "Understanding the next-generation API for Kubernetes service netwo
 tags:
 - cloud-native
 - devops
+- distributed-systems
 - kubernetes
 showComments: true
 ---

--- a/content/posts/2025-09-25-agic-vs-agc-which-ingress-solution-should-you-use-in-aks.md
+++ b/content/posts/2025-09-25-agic-vs-agc-which-ingress-solution-should-you-use-in-aks.md
@@ -6,6 +6,7 @@ tags:
 - aks
 - azure
 - cloud-native
+- distributed-systems
 - kubernetes
 - networking
 showComments: true

--- a/content/posts/2026-01-13-building-an-internal-ca-for-your-homelab-with-hashicorp-vault.md
+++ b/content/posts/2026-01-13-building-an-internal-ca-for-your-homelab-with-hashicorp-vault.md
@@ -3,7 +3,9 @@ title: Building an Internal CA for your Homelab with HashiCorp Vault
 date: 2026-01-13 18:00:00 +0100
 description: "Deploy Vault as your own CA using Portainer - say goodbye to self-signed certificate warnings"
 tags:
+- databases
 - devops
+- distributed-systems
 - homelab
 - security
 - vault


### PR DESCRIPTION
Adds two new taxonomy tags to relevant posts, inserted alphabetically into the existing front-matter tag lists with no other content changed.

- **`distributed-systems`** (20 posts): OpenStack/VIO/Heat, ACS/AKS-Engine, Kubernetes ingress & Gateway API, and security-runner posts.
- **`databases`** (8 posts): vCSA, SQL/chargeback, and secrets-store posts.

The HashiCorp Vault post receives both tags. 27 files changed, 28 insertions.