### PR TITLE
Upgrade Congo to v2.14.0 and Hugo to 0.164.0

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.154.5
+      HUGO_VERSION: 0.164.0
     steps:
       - name: Install Hugo CLI
         run: |

--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -1,6 +1,6 @@
-languageCode = "en"
-languageName = "English"
-languageDirection = "ltr"
+locale = "en"
+label = "English"
+direction = "ltr"
 weight = 1
 
 title = "Juanma's Blog"


### PR DESCRIPTION
Upgrades the Congo theme and the CI Hugo version together (v2.14.0 requires Hugo >= 0.158.0).

## Changes
- **Congo submodule** v2.12.2 → **v2.14.0**. The v2.14.0 release specifically fixes the "Author warning preventing sites from building" (#1165) and deprecated language-parameter warnings (#1162).
- **CI `HUGO_VERSION`** 0.154.5 → **0.164.0** (satisfies the new minimum; matches the local dev version).
- **`config/_default/languages.en.toml`**: renamed deprecated per-language keys `languageCode`/`languageName`/`languageDirection` → `locale`/`label`/`direction`.

## Verification (local build, Hugo 0.164.0 + Congo 2.14.0)
- Build **succeeds** — previously failed on 2.12.2 with `can't evaluate field Author`.
- All three language deprecation warnings **cleared**.
- Output unchanged: `<html lang=en>` and RSS `<language>en</language>` preserved.
- One benign warning remains — `.Site.Data` in the theme's `sharing-links.html` (upstream Congo, non-fatal, to be fixed by the maintainer).